### PR TITLE
Fix compilation with Clang on Windows

### DIFF
--- a/common/common_defs.h
+++ b/common/common_defs.h
@@ -28,7 +28,7 @@
 #ifndef COMMON_COMMON_DEFS_H
 #define COMMON_COMMON_DEFS_H
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #  include "compiler_gcc.h"
 #elif defined(_MSC_VER)
 #  include "compiler_msc.h"

--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -204,6 +204,7 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
  * Setup rotation macros similar to MSVS intrinsics.
  * These should recognized by compilers.
  */
+#ifndef _MSC_VER
 #ifndef _rotr16
 #define _rotr16(x,n)	((x>>n) + (x<<(16-n)))
 #endif
@@ -215,3 +216,4 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 #ifndef _rotr64
 #define _rotr64(x,n)	((x>>n) + (x<<(64-n)))
 #endif
+#endif /* _MSC_VER */


### PR DESCRIPTION
When building with Clang on Windows (clang-cl), `__clang__` is defined
but `__GNUC__` is not always defined. This caused the compiler detection
in common_defs.h to miss the GCC-compatible path and fall through to the
MSC branch or the "unrecognized compiler" warning.

Fix 1 - common/common_defs.h:
  Extend the GCC compiler check to also match `__clang__`, so Clang on
  Windows correctly includes compiler_gcc.h.

Fix 2 - common/compiler_gcc.h:
  When building with Clang on Windows, MSVC-compatible system headers
  already define `_rotr16`, `_rotr`, and `_rotr64` as intrinsics. Wrap
  the fallback macro definitions in `#ifndef _MSC_VER` to prevent
  redefinition errors.

Tested with clang-cl on Windows (x86_64).